### PR TITLE
[CI] Update GitHub Actions to use latest action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       filename: ${{ steps.build_zip.outputs.filename }}
     steps:
       - name: Checkout plugin source code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           path: plugin
       - name: Get plugin metadata
@@ -27,7 +27,7 @@ jobs:
         run: |
           echo "::set-output name=version::$(node -p "(require('./plugin/opensearch_dashboards.json').opensearchDashboardsVersion).match(/[.0-9]+/)[0]")"
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ steps.osd_version.outputs.version }}
@@ -63,7 +63,7 @@ jobs:
           echo "::set-output name=zip_path::$zip_path"
           echo "::set-output name=filename::$filename"
       - name: Upload plugin artifact
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # 3.1.2
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: plugin_artifact
           path: ${{ steps.build_zip.outputs.zip_path }}
@@ -81,11 +81,11 @@ jobs:
           echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
         shell: bash
       - name: Checkout plugin source code
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           path: plugin
       - name: Download plugin artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # 3.0.2
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
           name: plugin_artifact
           path: plugin/build


### PR DESCRIPTION
This commit updates the versions of actions/checkout, actions/upload-artifact and actions/download-artifact to the same version as other Bitergia components.

More info: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/